### PR TITLE
Use slug generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "numero2/contao-proper-filenames",
     "type": "contao-module",
-    "license": "LGPL-3.0+",
+    "license": "LGPL-3.0-or-later",
     "authors": [{
             "name": "numero2 - Agentur für Internetdienstleistungen",
             "homepage": "http://www.numero2.de"
@@ -9,7 +9,8 @@
     ],
     "require": {
         "contao/core-bundle": "4.*",
-        "contao-community-alliance/composer-plugin": "3.*"
+        "contao-community-alliance/composer-plugin": "3.*",
+        "ausi/slug-generator": "1.*"
     },
     "extra": {
         "contao": {

--- a/dca/tl_settings.php
+++ b/dca/tl_settings.php
@@ -11,13 +11,15 @@
  * @copyright 2017 numero2 - Agentur für Internetdienstleistungen
  */
 
+use Contao\System;
+use numero2\ProperFilenames\CheckFilenames;
 
 /**
  * Add palettes to tl_settings
  */
 $GLOBALS['TL_DCA']['tl_settings']['palettes']['default'] = str_replace(
     ',imageHeight',
-    ',imageHeight,checkFilenames,doNotTrimFilenames',
+    ',imageHeight,checkFilenames,doNotTrimFilenames,filenameValidCharacters,filenameValidCharactersLocale',
     $GLOBALS['TL_DCA']['tl_settings']['palettes']['default']
 );
 
@@ -36,4 +38,21 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['doNotTrimFilenames'] = array(
     'label'     => &$GLOBALS['TL_LANG']['tl_settings']['doNotTrimFilenames'],
     'inputType' => 'checkbox',
     'eval'      => array( 'tl_class' => 'w50 cbx' ),
+);
+
+$GLOBALS['TL_DCA']['tl_settings']['fields']['filenameValidCharacters'] = array(
+    'label'     => &$GLOBALS['TL_LANG']['tl_settings']['filenameValidCharacters'],
+    'inputType' => 'select',
+    'options_callback' => array( CheckFilenames::class, 'getValidCharacterOptions' ),
+    'reference' => &$GLOBALS['TL_LANG']['MSC']['validCharacters'],
+    'eval'      => array( 'tl_class' => 'w50', 'includeBlankOption' => true, 'decodeEntities' => true ),
+);
+
+$GLOBALS['TL_DCA']['tl_settings']['fields']['filenameValidCharactersLocale'] = array(
+    'label'     => &$GLOBALS['TL_LANG']['tl_settings']['filenameValidCharactersLocale'],
+    'inputType' => 'select',
+    'options_callback' => static function () {
+        return System::getLanguages();
+    },
+    'eval'      => array( 'tl_class' => 'w50', 'includeBlankOption' => true, 'chosen' => true ),
 );

--- a/languages/de/tl_settings.xlf
+++ b/languages/de/tl_settings.xlf
@@ -18,6 +18,22 @@
         <source>By default all renamed files with be trimmed to 32 characters.</source>
         <target>Dateinamen werden standardmässig nach 32 Zeichen abgeschnitten.</target>
     </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharacters.0">
+        <source>Valid filename characters</source>
+        <target>Gültige Dateinamen-Zeichen</target>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharacters.1">
+        <source>Here you can select a custom character set for automatically renamed files.</source>
+        <target>Hier kann ein individueller Zeichensatz für automatisch umbenannte Dateien ausgewählt werden.</target>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharactersLocale.0">
+        <source>Conversion locale</source>
+        <target>Konvertierungs-Lokalisierung</target>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharactersLocale.1">
+        <source>Here you can define a specific locale for the automatically renamed files. For example, selecting German will convert 'ö' to 'oe' instead of 'o'.</source>
+        <target>Hier kann eine spezifische Lokalisierung für die automatische umbenannten Dateien ausgewählt werden. Wenn z. B. Deutsch ausgewählt ist, wird 'ö' zu 'oe' statt 'o' umgewandelt.</target>
+    </trans-unit>
 </body>
 </file>
 </xliff>

--- a/languages/en/tl_settings.xlf
+++ b/languages/en/tl_settings.xlf
@@ -16,6 +16,18 @@
         <source>By default all renamed files with be trimmed to 32 characters.</source>
         <target>By default all renamed files with be trimmed to 32 characters.</target>
     </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharacters.0">
+        <source>Valid filename characters</source>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharacters.1">
+        <source>Here you can select a custom character set for automatically renamed files.</source>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharactersLocale.0">
+        <source>Conversion locale</source>
+    </trans-unit>
+    <trans-unit id="tl_settings.filenameValidCharactersLocale.1">
+        <source>Here you can define a specific locale for the automatically renamed files. For example, selecting German will convert 'ö' to 'oe' instead of 'o'.</source>
+    </trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
Implements #3

This PR adds a new feature to the file renaming, using `ausi/slug-generator`. This way you can define the valid character set just like in the website root (and also add additional valid character sets globally via the appropriate event in Contao 4). 😃 

Additionally you can set the locale for the slug generation, so that you could set it to German for instance, in order for Umlauts to be converted from `ö` to `oe` instead of `o` for example.

_Note:_ the PR should be fully compatible with Contao 3. However, I have not tested it in Contao 3.