### PR TITLE
Define PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "contao/core-bundle": "^4.13 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since version `2.2.0` (c15d225618f2e65d3645711affd89432672b47ce) this package requires at least PHP 8.0. If you install this extension in - for example - Contao 4.13 with PHP 7.4, the follwing error will occur: 

```
PHP Parse error:  syntax error, unexpected ',' in vendor/numero2/contao-proper-filenames/src/Command/CleanFilesCommand.php on   
   line 41 
```

Now, this PR does _not_ fix that. Even after merging this PR and releasing as `2.2.1`, this error will still occur when trying to install this package in Contao 4.13 under PHP 7.4, as version `2.2.0` will still continue to exist with the missing PHP version requirement.

To properly fix it you would actually have to go back to using Annotations instead of PHP Attributes instead. Or you could delete the `2.2.0` version tag (which is not ideal).

On the other hand it's probably not worth properly fixing it anyway. Anyone still running PHP 7.4 just has to put version `2.2.0` as a conflict in their project's composer.json.