### PR TITLE
Fix warning during file upload

### DIFF
--- a/src/EventListener/Hooks/CheckFilenamesListener.php
+++ b/src/EventListener/Hooks/CheckFilenamesListener.php
@@ -116,7 +116,7 @@ class CheckFilenamesListener {
                         ));
 
                         // write back new filename for use in further hooks
-                        $files[$i] = $newFilePath;
+                        $arrFiles[$i] = $newFile;
                     }
                 }
             }


### PR DESCRIPTION
Currently the following error occurs during a file upload:

```
ErrorException:
Warning: Undefined variable $newFilePath

  at vendor\numero2\contao-proper-filenames\src\EventListener\Hooks\CheckFilenamesListener.php:119
  at numero2\ProperFilenamesBundle\EventListener\Hooks\CheckFilenamesListener->renameFilesBackend(array('files/Lörem Ipsum.jpg'))
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Folder.php:1199)
  at Contao\DC_Folder->move(true)
     (vendor\contao\core-bundle\src\Resources\contao\classes\Ajax.php:487)
  at Contao\Ajax->executePostActions(object(DC_Folder))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:430)
  at Contao\Backend->getBackendModule('files', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)       
```

Neither the variable `$files` nor `$newFilePath` actually exist. This PR fixes that.