### PR TITLE
Fix duplicate database entries being created

### DIFF
--- a/src/EventListener/Hooks/CheckFilenamesListener.php
+++ b/src/EventListener/Hooks/CheckFilenamesListener.php
@@ -99,24 +99,32 @@ class CheckFilenamesListener {
 
                     $oFiles->rename($file, $newFile);
 
-                    $rootDir = System::getContainer()->getParameter('kernel.project_dir');
-
-                    // rename file in database
+                    // get the database entry created by Contao
                     $objFile = FilesModel::findByPath($file);
-                    $objFile->path = $newFile;
-                    $objFile->hash = md5_file($rootDir . '/' . $newFile);
-                    $objFile->name = $newFileName;
 
-                    if( $objFile->save() && $this->scopeMatcher->isBackendRequest($this->requestStack->getCurrentRequest()) ) {
+                    // check if file already exists under the new name
+                    if( FilesModel::findByPath($newFile) ) {
+                        // delete old file in database
+                        $objFile->delete();
+                    } else {
+                        $rootDir = System::getContainer()->getParameter('kernel.project_dir');
 
-                        Message::addInfo(sprintf(
-                            $GLOBALS['TL_LANG']['MSC']['proper_filenames_renamed']
-                        ,   $oldFileName
-                        ,   $newFileName
-                        ));
+                        // rename file in database
+                        $objFile->path = $newFile;
+                        $objFile->hash = md5_file($rootDir . '/' . $newFile);
+                        $objFile->name = $newFileName;
 
-                        // write back new filename for use in further hooks
-                        $files[$i] = $newFilePath;
+                        if( $objFile->save() && $this->scopeMatcher->isBackendRequest($this->requestStack->getCurrentRequest()) ) {
+
+                            Message::addInfo(sprintf(
+                                $GLOBALS['TL_LANG']['MSC']['proper_filenames_renamed']
+                            ,   $oldFileName
+                            ,   $newFileName
+                            ));
+    
+                            // write back new filename for use in further hooks
+                            $files[$i] = $newFilePath;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #26

This PR checks whether a database entry already exists under the new name that the file has already been renamed to - and if yes, deletes the database entry that was created by Contao during upload under the old name.

(Use **Hide whitespace** on GitHub to better see the changes.)